### PR TITLE
Remove Istio sidecar injection label from cronjob

### DIFF
--- a/k8s/cronjob.yaml
+++ b/k8s/cronjob.yaml
@@ -38,6 +38,3 @@ spec:
           restartPolicy: OnFailure
           imagePullSecrets:
             - name: osuakatsuki-registry-secret
-        metadata:
-          labels:
-            sidecar.istio.io/inject: "false"


### PR DESCRIPTION
## Summary
- Remove Istio sidecar injection label from cronjob spec
- Istio has been uninstalled from the cluster

## Test plan
- [ ] Verify cronjob runs correctly without the Istio label

🤖 Generated with [Claude Code](https://claude.com/claude-code)