### PR TITLE
Add health endpoint and HTTP readiness probe

### DIFF
--- a/app/api/rest/__init__.py
+++ b/app/api/rest/__init__.py
@@ -102,6 +102,10 @@ def init_middlewares(api: FastAPI) -> None:
 def init_routes(api: FastAPI) -> None:
     from .v1 import router as v1_router
 
+    @api.get("/_health")
+    async def health_check() -> str:
+        return "ok"
+
     api.include_router(v1_router)
 
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,15 @@ apps:
         repository: osuakatsuki/profile-history-service
         tag: latest
       port: 80
+      readinessProbe:
+        httpGet:
+          path: /_health
+          port: 80
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        successThreshold: 1
+        failureThreshold: 3
       resources:
         limits:
           cpu: 200m


### PR DESCRIPTION
## Summary
- Add `/_health` FastAPI endpoint that returns 200 OK
- Add HTTP readiness probe configuration
- Required for Kyverno policy compliance (require-probes)

## Test plan
- [ ] Verify `/_health` endpoint returns 200 OK
- [ ] Verify readiness probe works in Kubernetes

🤖 Generated with [Claude Code](https://claude.com/claude-code)